### PR TITLE
Add PDF ingestion to MemoRAG

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 faiss-cpu
 numpy
 python-dotenv
+PyPDF2


### PR DESCRIPTION
## Summary
- add PyPDF2 dependency
- ingest PDF files and build FAISS index with compressed embeddings
- adjust example `main` to show PDF ingestion

## Testing
- `python -m py_compile memorag.py`
- `python memorag.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686fdb7e4bd48326b71fbda37c1c0dbc