### PR TITLE
Use global memory when generating clue

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ MemoRAG is a next‐generation Retrieval-Augmented Generation framework designed
 ### Approach Overview
 
 1. **Ingest documents** – `ingest_documents()` reads PDFs from `sample_docs/`, splits them into ~4096 token chunks, compresses each with a small LLM and stores embeddings in a FAISS HNSW index.
-2. **Generate a clue** – `generate_clue()` produces a short draft answer for the user query.
+2. **Generate a clue** – `generate_clue(query, index, chunk_map)` uses the global memory to draft a short answer that guides retrieval.
 3. **Retrieve relevant memory** – `retrieve_chunks()` expands the clue into a retrieval query, embeds it, and searches the index for matching chunks.
 4. **Generate the final answer** – `generate_final_answer()` combines the original question with the retrieved chunk references to produce a final response.
 5. The optional script `ingestor.py` writes the index to `memory.index` and `memory_map.json` for later reuse.

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def load_index(index_path: str = "memory.index", map_path: str = "memory_map.jso
 
 
 def answer_query(query: str, index, chunk_map):
-    clue = generate_clue(query)
+    clue = generate_clue(query, index, chunk_map)
     chunks = retrieve_chunks(clue, index, chunk_map)
     if not chunks:
         return "No relevant information found."

--- a/benchmark.py
+++ b/benchmark.py
@@ -12,7 +12,7 @@ def run(baseline: bool):
     query = "How can I teach history to my student that have ADHD? What are the best pratices"
 
     start = time.perf_counter()
-    clue = memorag.generate_clue(query)
+    clue = memorag.generate_clue(query, index, chunk_map)
     clue_t = time.perf_counter() - start
 
     start = time.perf_counter()

--- a/memorag.py
+++ b/memorag.py
@@ -201,14 +201,70 @@ def build_memory_index(texts: list[str]):
 # Retrieval step
 # ------------------------------------------------------------
 
-def generate_clue(query: str) -> str:
-    """Generate a short draft answer (the "clue") for the user query."""
-    # Sec.3.2 - draft clue produced by expressive generator
-    with _time_call("generator_time"):
-        response = openai.chat.completions.create(
-            model="o4-mini",
-            messages=[{"role": "user", "content": query}]
+def generate_clue(
+    query: str,
+    index=None,
+    chunk_map: dict[int, dict] | None = None,
+    docs_dir: str = "sample_docs",
+    k: int = 2,
+) -> str:
+    """Generate a draft "clue" using the global memory if available.
+
+    MemoRAG's lightweight system should leverage the long-range memory when
+    crafting the initial clue.  If an index and chunk map are provided, we
+    perform a quick memory search to gather a few relevant snippets and pass
+    them to the generator alongside the original query.
+    """
+
+    memory_snippets: list[str] = []
+    if index is not None and chunk_map:
+        try:
+            query_vec = _get_embedding(query).reshape(1, -1)
+            _, indices = index.search(query_vec, k)
+            for idx in indices[0]:
+                info = chunk_map.get(int(idx))
+                if not info:
+                    continue
+                path = Path(docs_dir) / info["filename"]
+                start, *rest = info["pages"].split("-")
+                end = rest[0] if rest else start
+                try:
+                    reader = PdfReader(str(path))
+                    texts = [
+                        reader.pages[i].extract_text() or ""
+                        for i in range(int(start) - 1, int(end))
+                    ]
+                    memory_snippets.append(" ".join(texts).strip())
+                except Exception as err:
+                    logging.warning(
+                        "Failed reading %s pages %s: %s", path.name, info["pages"], err
+                    )
+        except Exception as err:
+            logging.warning("Initial memory search failed: %s", err)
+
+    messages = []
+    if memory_snippets:
+        context = "\n".join(memory_snippets)
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "Use the provided memory to draft a short answer that will"
+                    " guide retrieval."
+                ),
+            }
         )
+        messages.append(
+            {
+                "role": "user",
+                "content": f"Memory:\n{context}\n\nQuestion: {query}",
+            }
+        )
+    else:
+        messages = [{"role": "user", "content": query}]
+
+    with _time_call("generator_time"):
+        response = openai.chat.completions.create(model="o4-mini", messages=messages)
     return response.choices[0].message.content
 
 
@@ -266,7 +322,7 @@ def main():
     index, chunk_map = ingest_documents('sample_docs')
 
     query = "How can I teach history to my student that have ADHD? What are the best pratices"
-    clue = generate_clue(query)
+    clue = generate_clue(query, index, chunk_map)
     relevant_chunks = retrieve_chunks(clue, index, chunk_map)
     if not relevant_chunks:
         print("No relevant chunks found.")


### PR DESCRIPTION
## Summary
- expand `generate_clue` to consult the memory index before drafting a clue
- update callers in `app.py`, `benchmark.py`, and `memorag.py` to pass the index and map
- document new usage in README

## Testing
- `python -m py_compile memorag.py app.py benchmark.py ingestor.py`

------
https://chatgpt.com/codex/tasks/task_e_687180de07b88326955386d377efb93f