### PR TITLE
Use global memory when generating clue

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ MemoRAG is a next‐generation Retrieval-Augmented Generation framework designed
 ### Approach Overview
 
 1. **Ingest documents** – `ingest_documents()` reads PDFs from `sample_docs/`, splits them into ~4096 token chunks, compresses each with a small LLM and stores embeddings in a FAISS HNSW index.
-2. **Generate a clue** – `generate_clue()` produces a short draft answer for the user query.
+2. **Generate a clue** – `generate_clue(query, index, chunk_map)` uses the global memory to draft a short answer that guides retrieval.
 3. **Retrieve relevant memory** – `retrieve_chunks()` expands the clue into a retrieval query, embeds it, and searches the index for matching chunks.
-4. **Generate the final answer** – `generate_final_answer()` combines the original question with the retrieved chunk references to produce a final response.
+4. **Generate the final answer** – `generate_final_answer(query, chunks)` reads the referenced pages and crafts the final response.
 5. The optional script `ingestor.py` writes the index to `memory.index` and `memory_map.json` for later reuse.
 
 Set `MEMORAG_BASELINE=1` to disable caching and threading for baseline benchmarking (see `benchmark.py`).

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def load_index(index_path: str = "memory.index", map_path: str = "memory_map.jso
 
 
 def answer_query(query: str, index, chunk_map):
-    clue = generate_clue(query)
+    clue = generate_clue(query, index, chunk_map)
     chunks = retrieve_chunks(clue, index, chunk_map)
     if not chunks:
         return "No relevant information found."

--- a/benchmark.py
+++ b/benchmark.py
@@ -12,7 +12,7 @@ def run(baseline: bool):
     query = "How can I teach history to my student that have ADHD? What are the best pratices"
 
     start = time.perf_counter()
-    clue = memorag.generate_clue(query)
+    clue = memorag.generate_clue(query, index, chunk_map)
     clue_t = time.perf_counter() - start
 
     start = time.perf_counter()


### PR DESCRIPTION
## Summary
- expand `generate_clue` to consult the memory index before drafting a clue
- update callers in `app.py`, `benchmark.py`, and `memorag.py` to pass the index and map
- document new usage in README
- make final answer read retrieved page text for context

## Testing
- `python -m py_compile memorag.py app.py benchmark.py ingestor.py`

------
https://chatgpt.com/codex/tasks/task_e_687180de07b88326955386d377efb93f